### PR TITLE
fix the bug of 'bom match',change the destroy() function to EndModal()

### DIFF
--- a/nextPCB_plugin/gui_pcb/summary/summary_panel.py
+++ b/nextPCB_plugin/gui_pcb/summary/summary_panel.py
@@ -311,8 +311,8 @@ class SummaryPanelNextpcb(UiSummaryPanelNextpcb):
     def on_bom_match(self, e):
         dlg = NextPCBTools(self, self._board_manager)
         result = dlg.ShowModal()
-        if result in (wx.ID_OK, wx.ID_CANCEL):
-            dlg.Destroy()
+        # if result in (wx.ID_OK, wx.ID_CANCEL):
+        #     dlg.Destroy()
         self.load_Designator()
 
 

--- a/nextPCB_plugin/kicad_nextpcb_new/mainwindow.py
+++ b/nextPCB_plugin/kicad_nextpcb_new/mainwindow.py
@@ -332,7 +332,8 @@ class NextPCBTools(wx.Dialog):
 
     def quit_dialog(self, e):
         """Destroy dialog on close"""
-        self.Destroy()
+        #self.Destroy()
+        self.EndModal(wx.ID_OK)
 
     def init_store(self):
         """Initialize the store of part assignments"""


### PR DESCRIPTION
1、将mainwindows.py中的quit_dialog()函数中的self.destroy()替换成self.EndModal(wx.ID_OK)

2、将summary_panel.py中的on_bom_match()函数，315行和316行，注释掉。